### PR TITLE
XCode 12 compilation fixes

### DIFF
--- a/Plugins/iOS/UnityARKit/NativeInterface/AREnvironmentProbe.mm
+++ b/Plugins/iOS/UnityARKit/NativeInterface/AREnvironmentProbe.mm
@@ -162,7 +162,7 @@ extern "C" void session_SetEnvironmentProbeAnchorCallbacks(const void* session, 
         envProbeAnchorCallbacks->_anchorUpdatedCallback = envProbeAnchorUpdatedCallback;
         envProbeAnchorCallbacks->_anchorRemovedCallback = envProbeAnchorRemovedCallback;
         if (@available(iOS 12.0, *)) {
-            [nativeSession->_classToCallbackMap setObject:envProbeAnchorCallbacks forKey:[AREnvironmentProbeAnchor class]];
+            [nativeSession->_classToCallbackMap setObject:envProbeAnchorCallbacks forKey: (id<NSCopying>)[AREnvironmentProbeAnchor class]];
         } 
     }
 }

--- a/Plugins/iOS/UnityARKit/NativeInterface/ARKitNativeObjectDetection.mm
+++ b/Plugins/iOS/UnityARKit/NativeInterface/ARKitNativeObjectDetection.mm
@@ -109,7 +109,7 @@ extern "C" void session_SetObjectAnchorCallbacks(const void* session, UNITY_AR_O
         objectAnchorCallbacks->_anchorRemovedCallback = objectAnchorRemovedCallback;
         if (@available(iOS 12.0, *))
         {
-            [nativeSession->_classToCallbackMap setObject:objectAnchorCallbacks forKey:[ARObjectAnchor class]];
+            [nativeSession->_classToCallbackMap setObject:objectAnchorCallbacks forKey: (id<NSCopying>)[ARObjectAnchor class]];
         }
     }
 }

--- a/Plugins/iOS/UnityARKit/NativeInterface/ARSessionNative.mm
+++ b/Plugins/iOS/UnityARKit/NativeInterface/ARSessionNative.mm
@@ -784,7 +784,7 @@ extern "C" void session_SetPlaneAnchorCallbacks(const void* session, UNITY_AR_AN
     anchorCallbacks->_anchorAddedCallback = anchorAddedCallback;
     anchorCallbacks->_anchorUpdatedCallback = anchorUpdatedCallback;
     anchorCallbacks->_anchorRemovedCallback = anchorRemovedCallback;
-    [nativeSession->_classToCallbackMap setObject:anchorCallbacks forKey:[ARPlaneAnchor class]];
+    [nativeSession->_classToCallbackMap setObject:anchorCallbacks forKey: (id<NSCopying>)[ARPlaneAnchor class]];
 }
 
 extern "C" void session_SetUserAnchorCallbacks(const void* session, UNITY_AR_USER_ANCHOR_CALLBACK userAnchorAddedCallback, 
@@ -796,7 +796,7 @@ extern "C" void session_SetUserAnchorCallbacks(const void* session, UNITY_AR_USE
     userAnchorCallbacks->_anchorAddedCallback = userAnchorAddedCallback;
     userAnchorCallbacks->_anchorUpdatedCallback = userAnchorUpdatedCallback;
     userAnchorCallbacks->_anchorRemovedCallback = userAnchorRemovedCallback;
-    [nativeSession->_classToCallbackMap setObject:userAnchorCallbacks forKey:[ARAnchor class]];
+    [nativeSession->_classToCallbackMap setObject:userAnchorCallbacks forKey: (id<NSCopying>)[ARAnchor class]];
 }
 
 extern "C" void session_SetFaceAnchorCallbacks(const void* session, UNITY_AR_FACE_ANCHOR_CALLBACK faceAnchorAddedCallback,
@@ -809,7 +809,7 @@ extern "C" void session_SetFaceAnchorCallbacks(const void* session, UNITY_AR_FAC
     faceAnchorCallbacks->_anchorAddedCallback = faceAnchorAddedCallback;
     faceAnchorCallbacks->_anchorUpdatedCallback = faceAnchorUpdatedCallback;
     faceAnchorCallbacks->_anchorRemovedCallback = faceAnchorRemovedCallback;
-    [nativeSession->_classToCallbackMap setObject:faceAnchorCallbacks forKey:[ARFaceAnchor class]];
+    [nativeSession->_classToCallbackMap setObject:faceAnchorCallbacks forKey: (id<NSCopying>)[ARFaceAnchor class]];
 #endif
 }
 
@@ -824,7 +824,7 @@ extern "C" void session_SetImageAnchorCallbacks(const void* session, UNITY_AR_IM
         imageAnchorCallbacks->_anchorAddedCallback = imageAnchorAddedCallback;
         imageAnchorCallbacks->_anchorUpdatedCallback = imageAnchorUpdatedCallback;
         imageAnchorCallbacks->_anchorRemovedCallback = imageAnchorRemovedCallback;
-        [nativeSession->_classToCallbackMap setObject:imageAnchorCallbacks forKey:[ARImageAnchor class]];
+        [nativeSession->_classToCallbackMap setObject:imageAnchorCallbacks forKey: (id<NSCopying>)[ARImageAnchor class]];
     }
 }
 


### PR DESCRIPTION
I recently ran into issue building an old project on XCode 12.

Since your archive repo was showing up in searches, I thought I'd contribute a fix for any other people struggling with the abandoned UnityARKit plugin.

You can see some discussion related to this error here: https://github.com/Unity-Technologies/facial-ar-remote/issues/51

While Unity may suggest switching to newer supported frameworks, I thought people may appreciate the option of a light weight patch.